### PR TITLE
🐞fix: 교육과정 이름 길이 수정

### DIFF
--- a/src/main/java/com/syi/project/course/dto/CourseDTO.java
+++ b/src/main/java/com/syi/project/course/dto/CourseDTO.java
@@ -53,13 +53,13 @@ public class CourseDTO {
 
   @Schema(description = "교육 과정명", example = "자바 스프링 백엔드 과정")
   @NotBlank(groups = Create.class,message = "교육 과정명은 필수입니다.")
-  @Size(min = 2, max = 20,message = "교육 과정명은 2자 이상 20자 이하이어야 합니다.")
+  @Size(min = 2, max = 50,message = "교육 과정명은 2자 이상 50자 이하이어야 합니다.")
   private String name;
 
   @Schema(description = "교육과정 설명", example = "자바와 스픠링을 배우고 익힙니다.")
   //@NotBlank(message = "교육과정 설명은 필수입니다.")
   @Nullable
-  @Size(min = 0, max = 50, message = "교육 과정 설명은 50자 이하이어야 합니다.")
+  @Size(min = 0, max = 100, message = "교육 과정 설명은 100자 이하이어야 합니다.")
   private String description;
 
   @Schema(description = "담당자명", example = "황정미")

--- a/src/main/java/com/syi/project/course/entity/Course.java
+++ b/src/main/java/com/syi/project/course/entity/Course.java
@@ -37,13 +37,13 @@ public class Course {
   private Long id;
 
   @NotNull
-  @Size(min = 2, max = 20, message = "교육 과정명은 2자 이상 20자 이하이어야 합니다.")
-  @Column(nullable = false, unique = true, length = 20)
+  @Size(min = 2, max = 50, message = "교육 과정명은 2자 이상 50자 이하이어야 합니다.")
+  @Column(nullable = false, unique = true, length = 50)
   private String name;
 
   //@NotNull
-  @Size(max = 50, message = "교육 과정 설명은 50자 이하이어야 합니다.")
-  @Column(length = 50)
+  @Size(max = 100, message = "교육 과정 설명은 100자 이하이어야 합니다.")
+  @Column(length = 100)
   private String description;
 
   @NotNull


### PR DESCRIPTION
교육과정 이름(name) 길이는 50자로 수정하고, 내용(description)은 100자까지 허용하는 것으로 수정했습니다.