### PR TITLE
🐞fix: 출석률 계산 시 첫날 제외 로직 제거

### DIFF
--- a/src/main/java/com/syi/project/attendance/AttendanceCalculator.java
+++ b/src/main/java/com/syi/project/attendance/AttendanceCalculator.java
@@ -38,7 +38,7 @@ public class AttendanceCalculator {
     log.info("dailyStats size: {}, startDate: {}, endDate: {}, holidays: {}", dailyStats.size(),
         startDate, endDate, holidays);
 
-    // 첫 날 제외하고 유효한 전체 출석일 (115일)
+    // 유효한 전체 출석일 (115일 - 주말, 공휴일 제외)
     List<LocalDate> validDays = getValidDays(startDate, endDate, holidays);
 
     // validDays가 비어있는 경우 처리
@@ -137,7 +137,7 @@ public class AttendanceCalculator {
       LocalDate date = stats.getDate();
 
       // 유효한 출석일만 고려
-      if (!validDays.contains(date) || date.isEqual(startDate)) {
+      if (!validDays.contains(date)) {
         continue;
       }
 
@@ -184,14 +184,14 @@ public class AttendanceCalculator {
     }
 
     log.debug("최종 전체 실제 출석일 수: {}", totalAttendanceDays);
-    double realValidDaysSize = (double) validDays.size() - 1;
+    double realValidDaysSize = (double) validDays.size();
     if (realValidDaysSize <= 0) {
-      log.warn("유효 출석일 수가 1 이하입니다. 출석률을 0.0으로 반환합니다.");
+      log.warn("유효 출석일 수가 0 입니다. 출석률을 0.0으로 반환합니다.");
       return 0.0;
     }
     log.debug("(double) validDays.size()) - 1: {}",realValidDaysSize);
 
-    log.info("(최종) 전체 실제 출석일 수: {}, 1일 감소된 유효일 수: {}", totalAttendanceDays, realValidDaysSize);
+    log.info("(최종) 전체 실제 출석일 수: {}, 유효일 수: {}", totalAttendanceDays, realValidDaysSize);
     return roundToTwoDecimalPlaces((totalAttendanceDays / realValidDaysSize) * 100);
   }
 
@@ -247,10 +247,6 @@ public class AttendanceCalculator {
       }
 
 
-/*      // 첫 번째 차수(1차)만 첫째 날을 제외
-      if (periodIndex == 0 && periodDays.size() > 1) {
-        periodDays = periodDays.subList(1, periodDays.size()); // 첫째 날 제외
-      }*/
 
       // 이 세그먼트가 마지막 기록된 날짜를 포함하는지 확인
       boolean containsLastDate = periodDays.stream()
@@ -491,8 +487,7 @@ public class AttendanceCalculator {
           "시작일", periodDays.get(0),
           "종료일", periodDays.get(periodDays.size()-1),
           "일수", periodDays.size(),
-          "날짜들", periodDays,
-          "첫차여부", periodIndex == 1
+          "날짜들", periodDays
       ));
 //      workingDays = workingDays.subList(Math.min(SEGMENT_DAYS, workingDays.size()), workingDays.size());
       workingDays = workingDays.subList(segmentSize, workingDays.size());

--- a/src/main/java/com/syi/project/attendance/service/AttendanceService.java
+++ b/src/main/java/com/syi/project/attendance/service/AttendanceService.java
@@ -1154,17 +1154,6 @@ public class AttendanceService {
     log.info("해당 기간에 속하는 날짜들 사이즈: {}", courseDates.size());
 
     LocalDate startDate;
-    // 해당 차수의 시작일과 종료일
-    /*if (termLabel.equals("1차")) {
-      startDate = ((LocalDate) result.get("시작일")).minusDays(1);
-      List<LocalDate> newCourseDates = new ArrayList<>(courseDates);
-      newCourseDates.add(0, startDate);
-      courseDates = newCourseDates;
-      log.info("1차라서 교육과정 시작일 {} 을 courseDates에 포함시켰음 : {}", startDate, courseDates.size());
-      //courseDates = courseDates.subList(1, courseDates.size()); // 시작날짜 포함
-    } else {
-      startDate = (LocalDate) result.get("시작일");
-    }*/
     startDate = (LocalDate) result.get("시작일");
     LocalDate endDate = (LocalDate) result.get("종료일");
 
@@ -1332,13 +1321,6 @@ public class AttendanceService {
 
     AttendancePrintResponseDto.SummaryPageDto summaryPage = new AttendancePrintResponseDto.SummaryPageDto();
     List<AttendancePrintResponseDto.StudentSummaryDto> summaries = new ArrayList<>();
-
-/*    if (termLabel.equals("1차")) {
-      courseDates.subList(1, courseDates.size());
-      startDate = startDate.plusDays(1);
-      log.info("출석률 계산을 위해 1차라서 포함시켰던 교육과정 시작일 {} 을 배제시킴 : {}", startDate, courseDates.size());
-      //courseDates = courseDates.subList(1, courseDates.size());
-    }*/
 
     int totalWorkingDays = courseDates.size();
     log.debug("소정 출석일: {}", totalWorkingDays);


### PR DESCRIPTION
- 전체 출석률 계산 시 첫날 제외(-1) 로직 제거
- 출석 데이터 필터링 시 startDate 제외 조건 제거
- 20일 단위 출석률 계산 시 첫차수 첫날 제외 코드 제거
- 모든 회차에 동일한 출석률 계산 로직 적용
- 소정출석일과 실제 출석일 계산 방식 일관성 유지

이 변경으로 첫날 결석자와 출석자 간의 출석률 계산이 공정하게 처리됩니다.