### PR TITLE
✨feat: 출석 상세보기에 일괄 삭제 기능 추가

### DIFF
--- a/src/main/java/com/syi/project/attendance/controller/admin/AdminAttendanceController.java
+++ b/src/main/java/com/syi/project/attendance/controller/admin/AdminAttendanceController.java
@@ -7,6 +7,7 @@ import com.syi.project.attendance.dto.response.AttendanceResponseDTO;
 import com.syi.project.attendance.dto.response.AttendanceResponseDTO.AttendDetailDTO;
 import com.syi.project.attendance.dto.response.AttendanceResponseDTO.AttendListResponseDTO;
 import com.syi.project.attendance.dto.response.AttendanceResponseDTO.AttendancePrintResponseDto;
+import com.syi.project.attendance.dto.response.AttendanceResponseDTO.DeleteResultDto;
 import com.syi.project.attendance.service.AttendanceService;
 import com.syi.project.auth.service.CustomUserDetails;
 import com.syi.project.auth.service.MemberService;
@@ -28,6 +29,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -189,5 +191,18 @@ public class AdminAttendanceController {
     return ResponseEntity.ok(attendancePrintDataByCourseId);
   }
 
+  /**
+   * 특정 날짜의 특정 학생의 모든 출석 데이터 일괄 삭제
+   * @return 삭제된 데이터 수를 포함한 결과 정보
+   */
+  @DeleteMapping("/bulk-all")
+  public ResponseEntity<DeleteResultDto> bulkDeleteAllAttendances(
+      @RequestParam String date,
+      @RequestParam Long studentId,
+      @RequestParam Long courseId) {
+
+    DeleteResultDto result = attendanceService.bulkDeleteAllAttendances(date, studentId, courseId);
+    return ResponseEntity.ok(result);
+  }
 
 }

--- a/src/main/java/com/syi/project/attendance/dto/response/AttendanceResponseDTO.java
+++ b/src/main/java/com/syi/project/attendance/dto/response/AttendanceResponseDTO.java
@@ -296,6 +296,19 @@ public class AttendanceResponseDTO {
     }
   }
 
+  @Getter
+  @ToString
+  public static class DeleteResultDto{
+    private Long deletedCount;
+    private String message;
+
+    @Builder
+    public DeleteResultDto(Long deletedCount, String message ) {
+      this.deletedCount = deletedCount;
+      this.message = message;
+    }
+  }
+
 
   private Long attendanceId;
 

--- a/src/main/java/com/syi/project/attendance/repository/AttendanceRepositoryCustom.java
+++ b/src/main/java/com/syi/project/attendance/repository/AttendanceRepositoryCustom.java
@@ -6,6 +6,7 @@ import com.syi.project.attendance.dto.request.AttendanceRequestDTO.AllAttendance
 import com.syi.project.attendance.dto.response.AttendanceResponseDTO.AttendListResponseDTO;
 import com.syi.project.attendance.dto.response.AttendanceResponseDTO.AttendanceStatusListDTO;
 import com.syi.project.attendance.dto.response.AttendanceResponseDTO.AttendanceTableDTO;
+import com.syi.project.attendance.dto.response.AttendanceResponseDTO.DeleteResultDto;
 import com.syi.project.attendance.dto.response.AttendanceResponseDTO.MemberInfoInDetail;
 import com.syi.project.attendance.entity.Attendance;
 import java.time.LocalDate;
@@ -43,4 +44,6 @@ public interface AttendanceRepositoryCustom {
   List<AttendanceDailyStats> findAttendanceStatsByStudentIdAndCourseIdAndDates(Long id, Long courseId, LocalDate startDate, LocalDate endDate);
 
   Optional<Attendance> findByMemberIdAndDateAndPeriodId(Long studentId, LocalDate today, Long id);
+
+  DeleteResultDto deleteAllAttendancesByDateAndStudentAndCourse(LocalDate date, Long studentId, Long courseId);
 }

--- a/src/main/java/com/syi/project/attendance/repository/AttendanceRepositoryImpl.java
+++ b/src/main/java/com/syi/project/attendance/repository/AttendanceRepositoryImpl.java
@@ -15,6 +15,7 @@ import com.syi.project.attendance.dto.request.AttendanceRequestDTO.AllAttendance
 import com.syi.project.attendance.dto.response.AttendanceResponseDTO.AttendListResponseDTO;
 import com.syi.project.attendance.dto.response.AttendanceResponseDTO.AttendanceStatusListDTO;
 import com.syi.project.attendance.dto.response.AttendanceResponseDTO.AttendanceTableDTO;
+import com.syi.project.attendance.dto.response.AttendanceResponseDTO.DeleteResultDto;
 import com.syi.project.attendance.dto.response.AttendanceResponseDTO.MemberInfoInDetail;
 import com.syi.project.attendance.entity.Attendance;
 import com.syi.project.common.enums.AttendanceStatus;
@@ -668,6 +669,39 @@ public class AttendanceRepositoryImpl implements AttendanceRepositoryCustom{
             .select(attendance)
             .fetchOne()
     );
+  }
+
+  @Override
+  public DeleteResultDto deleteAllAttendancesByDateAndStudentAndCourse(LocalDate date,
+      Long studentId, Long courseId) {
+
+    // 삭제할 데이터 수 조회
+    Long count = countByDateAndStudentAndCourse(date, studentId, courseId);
+
+    // null 체크 추가
+    if (count == null || count == 0) {
+      return new DeleteResultDto(0L, "삭제할 출석 데이터가 없습니다.");
+    }
+
+    Long deletedCount = queryFactory.delete(attendance)
+        .where(attendance.date.eq(date)
+            .and(attendance.memberId.eq(studentId))
+            .and(attendance.courseId.eq(courseId)))
+        .execute();
+
+    return new DeleteResultDto(deletedCount, deletedCount + "개의 출석 정보가 삭제되었습니다.");
+  }
+
+  private Long countByDateAndStudentAndCourse(LocalDate date, Long studentId, Long courseId) {
+
+    // 카운트 결과를 Long으로 반환
+    return queryFactory.select(attendance.count())
+        .from(attendance)
+        .where(attendance.date.eq(date)
+            .and(attendance.memberId.eq(studentId))
+            .and(attendance.courseId.eq(courseId)))
+        .fetchOne();
+
   }
 
 

--- a/src/main/java/com/syi/project/attendance/service/AttendanceService.java
+++ b/src/main/java/com/syi/project/attendance/service/AttendanceService.java
@@ -34,6 +34,7 @@ import com.syi.project.attendance.dto.response.AttendanceResponseDTO.AttendanceP
 import com.syi.project.attendance.dto.response.AttendanceResponseDTO.AttendancePrintResponseDto.SummaryPageDto;
 import com.syi.project.attendance.dto.response.AttendanceResponseDTO.AttendanceStatusListDTO;
 import com.syi.project.attendance.dto.response.AttendanceResponseDTO.AttendanceTableDTO;
+import com.syi.project.attendance.dto.response.AttendanceResponseDTO.DeleteResultDto;
 import com.syi.project.attendance.dto.response.AttendanceResponseDTO.MemberInfoInDetail;
 import com.syi.project.attendance.entity.Attendance;
 import com.syi.project.attendance.repository.AttendanceRepository;
@@ -57,6 +58,8 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.format.TextStyle;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -1528,6 +1531,32 @@ public class AttendanceService {
     } catch (Exception e) {
       log.error("{}일 미기록 출석 수동 처리 중 오류 발생", date, e);
     }
+  }
+
+  /**
+   * 특정 날짜의 특정 학생의 모든 출석 데이터 일괄 삭제 (모든 페이지 포함)
+   *
+   * @return 삭제된 데이터 수를 포함한 결과 정보
+   */
+  @Transactional
+  public DeleteResultDto bulkDeleteAllAttendances(String dateStr, Long studentId, Long courseId) {
+
+    LocalDate date;
+
+    try {
+      // 문자열 날짜를 LocalDate로 변환
+      date = LocalDate.parse(dateStr, DateTimeFormatter.ISO_DATE);
+    } catch (DateTimeParseException e) {
+      throw new IllegalArgumentException("잘못된 날짜 형식입니다. YYYY-MM-DD 형식으로 입력해주세요.");
+    }
+
+    // null 체크
+    if (studentId == null || courseId == null) {
+      throw new IllegalArgumentException("학생 ID와 강의 ID는 필수 입력 값입니다.");
+    }
+
+    // 리포지토리에서 삭제 실행 및 결과 반환
+    return attendanceRepository.deleteAllAttendancesByDateAndStudentAndCourse(date, studentId, courseId);
   }
 }
 


### PR DESCRIPTION
- 해당하는 날짜의 해당하는 학생의 출석 데이터를 일괄적으로 삭제하는 기능을 만들었음
- 이를 통해 관리자단에서 일괄적으로 삭제하고자 하는 출석 데이터를 삭제할 수 있음