### PR TITLE
🐞fix:동아리일지 수정 후 서버오류발생 해결

### DIFF
--- a/src/main/java/com/syi/project/club/file/ClubFileRepository.java
+++ b/src/main/java/com/syi/project/club/file/ClubFileRepository.java
@@ -1,12 +1,16 @@
 package com.syi.project.club.file;
 
+import com.syi.project.file.enums.FileStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
-public interface ClubFileRepository extends JpaRepository<ClubFile, Integer> {
+public interface ClubFileRepository extends JpaRepository<ClubFile, Long> {
 
     List<ClubFile> findByClubId(Long id);
+
 }

--- a/src/main/java/com/syi/project/club/service/ClubService.java
+++ b/src/main/java/com/syi/project/club/service/ClubService.java
@@ -17,6 +17,7 @@ import com.syi.project.common.utils.S3Uploader;
 import com.syi.project.file.dto.FileDownloadDTO;
 import com.syi.project.file.dto.FileResponseDTO;
 import com.syi.project.file.entity.File;
+import com.syi.project.file.enums.FileStatus;
 import com.syi.project.file.repository.FileRepository;
 import com.syi.project.file.service.FileService;
 import jakarta.persistence.EntityNotFoundException;
@@ -275,11 +276,13 @@ public class ClubService {
             // 기존 파일이 있는 경우 삭제하고 새 파일로 교체
             File existingFile = clubFile.getFile();
             if (existingFile != null) {
-                fileService.deleteFile(existingFile.getId(), member);
+                existingFile.delete(member); // 논리적 삭제
+                fileRepository.save(existingFile); // 상태 변경 저장
             }
 
             // 새 파일 업로드
             File uploadedFile = fileService.uploadFile(file, dirName, member);
+            //기존 ClubFile의 파일만 교체 (레코드는 유지)
             clubFile.updateFile(uploadedFile);
             clubFileRepository.save(clubFile);
 
@@ -295,6 +298,7 @@ public class ClubService {
 
             return FileResponseDTO.from(uploadedFile, s3Uploader);
         }
+
     }
 
     // 클럽 파일 정보 조회 메서드


### PR DESCRIPTION
* ClubFile테이블 속 Primary Key 중복
* 중복데이터로 동일ID 존재
* Files테이블 포함 이전 수정이력 존재
* 기존 데이터 유지하고 ClubFile의 파일만 교체로 수정함
* Files 논리적삭제 처리함